### PR TITLE
Updated TiIdentity.yml to fix API doc pub issue

### DIFF
--- a/apidoc/TiIdentity.yml
+++ b/apidoc/TiIdentity.yml
@@ -274,7 +274,7 @@ properties:
     platforms: [iphone, ipad]
 
   - name: ERROR_TOUCH_ID_LOCKOUT
-    summary: 
+    summary: |
          Constant indicating that Touch ID has locked out.
          Note: This constant has been deprecated for iOS 11 and later. Use
          <Modules.TiIdentity.ERROR_BIOMETRY_LOCKOUT> for apps targeting iOS 11


### PR DESCRIPTION
Line 277 was missing the "|" character that treats the following block of text as text. This missing character is causing this module from properly rendering to the API docs.