### PR TITLE
Updated KeychainItem.yml

### DIFF
--- a/apidoc/KeychainItem.yml
+++ b/apidoc/KeychainItem.yml
@@ -1,6 +1,6 @@
 name: Modules.Identity.KeychainItem
 summary: Represents a keychain item to communicate with the native iOS keychain.
-platforms: [iphone, ipad]
+platforms: [iphone, ipad, android]
 since: {iphone: "6.1.0", ipad: "6.1.0", android: "6.1.0"}
 extends: Titanium.Module
 description: |


### PR DESCRIPTION
The object platforms﻿ didn't have the member of "android" in it's array. Added it now and rebuilt the docs locally to confirm: platforms: [iphone, ipad, android]﻿

See https://jira.appcelerator.org/browse/TIDOC-3125 for details.