### PR TITLE
Danger check

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,6 +3,7 @@
 // requires
 const junit = require('@seadub/danger-plugin-junit').default;
 const dependencies = require('@seadub/danger-plugin-dependencies').default;
+const moduleLint = require('@seadub/danger-plugin-titanium-module').default;
 const fs = require('fs');
 const path = require('path');
 const ENV = process.env;
@@ -36,6 +37,7 @@ async function main() {
 		dependencies({ type: 'npm' }),
 		linkToArtifacts(),
 		checkLintLog(),
+		moduleLint(),
 	]);
 }
 main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1205,6 +1205,35 @@
 				"xmldom": "^0.1.27"
 			}
 		},
+		"@seadub/danger-plugin-titanium-module": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@seadub/danger-plugin-titanium-module/-/danger-plugin-titanium-module-0.0.1.tgz",
+			"integrity": "sha512-JIW4UyodxLZYAv5qDJE5pU1mvHjeGpZ6TjTj/8R6mimhNWum7huzGhtwk+EYeeB7UB3FQrfuVxNiwnyWif82rg==",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^8.1.0",
+				"semver": "^7.1.1"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"semver": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.1.2.tgz",
+					"integrity": "sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ==",
+					"dev": true
+				}
+			}
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"@seadub/clang-format-lint": "0.0.2",
 		"@seadub/danger-plugin-dependencies": "^0.1.0",
 		"@seadub/danger-plugin-junit": "^0.1.2",
+		"@seadub/danger-plugin-titanium-module": "0.0.1",
 		"clang-format": "^1.2.3",
 		"commitizen": "^4.0.3",
 		"danger": "^7.1.0",


### PR DESCRIPTION
This is a Work in Progress PR to see if my new danger.js plugin helps avoid common module project issues:
- mismatched sdk versions between Jenkinsfile, titanium.xcconfig, and eventually test/unit/karma.unit.config.js
- sdk versions in Jenkinsfile/titanium.xcconfig that aren't >= minSDK in manifest (the greater of the declared minSDK values for multi-platforms)
- differing moduleid or guide between manifests
- bumping apiversion but not minsdk in manifest
- bumping minsdk but not bumping version a major rev in manifest
- bumping version in manifest and not bumping equivalent level in package.json
- missing manifest files
- bad platform value in manifest

