### PR TITLE
feat(android): Use reason + subtitle and text

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.1
+version: 3.0.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-identity

--- a/android/src/ti/identity/FingerPrintHelper.java
+++ b/android/src/ti/identity/FingerPrintHelper.java
@@ -125,7 +125,9 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 		mSelfCancelled = false;
 
 		final BiometricPrompt.PromptInfo.Builder promptInfo = new BiometricPrompt.PromptInfo.Builder();
-		promptInfo.setTitle("Scan Fingerprint");
+		promptInfo.setTitle(TitaniumIdentityModule.reason);
+		promptInfo.setDescription(TitaniumIdentityModule.reasonText);
+		promptInfo.setSubtitle(TitaniumIdentityModule.reasonSubtitle);
 		promptInfo.setNegativeButtonText("Cancel");
 
 		final Executor executor = Executors.newSingleThreadExecutor();

--- a/android/src/ti/identity/KeychainItemProxy.java
+++ b/android/src/ti/identity/KeychainItemProxy.java
@@ -157,7 +157,9 @@ public class KeychainItemProxy extends KrollProxy
 				};
 
 				final BiometricPrompt.PromptInfo.Builder promptInfo = new BiometricPrompt.PromptInfo.Builder();
-				promptInfo.setTitle("Scan Fingerprint");
+				promptInfo.setTitle(TitaniumIdentityModule.reason);
+				promptInfo.setSubtitle(TitaniumIdentityModule.reasonSubtitle);
+				promptInfo.setDescription(TitaniumIdentityModule.reasonText);
 				promptInfo.setNegativeButtonText("Cancel");
 				biometricPromptInfo = promptInfo.build();
 			}

--- a/android/src/ti/identity/TitaniumIdentityModule.java
+++ b/android/src/ti/identity/TitaniumIdentityModule.java
@@ -27,6 +27,9 @@ public class TitaniumIdentityModule extends KrollModule
 	public static final int PERMISSION_CODE_FINGERPRINT = 99;
 
 	public static final String PROPERTY_AUTHENTICATION_POLICY = "authenticationPolicy";
+	public static final String PROPERTY_REASON = "reason";
+	public static final String PROPERTY_REASON_SUBTITLE = "reasonSubtitle";
+	public static final String PROPERTY_REASON_TEXT = "reasonText";
 
 	@Kroll.constant
 	public static final int SUCCESS = 0;
@@ -89,6 +92,9 @@ public class TitaniumIdentityModule extends KrollModule
 	private Throwable fingerprintHelperException;
 
 	private static int authenticationPolicy = AUTHENTICATION_POLICY_BIOMETRICS;
+	public static String reason = "Biometric authentication";
+	public static String reasonSubtitle = "";
+	public static String reasonText = "";
 
 	public TitaniumIdentityModule()
 	{
@@ -142,6 +148,16 @@ public class TitaniumIdentityModule extends KrollModule
 		if (params == null || mfingerprintHelper == null) {
 			return;
 		}
+		if (params.containsKey(PROPERTY_REASON)) {
+			reason = TiConvert.toString(params.get(PROPERTY_REASON), reason);
+		}
+		if (params.containsKey(PROPERTY_REASON_TEXT)) {
+			reasonText = TiConvert.toString(params.get(PROPERTY_REASON_TEXT), "");
+		}
+		if (params.containsKey(PROPERTY_REASON_SUBTITLE)) {
+			reasonSubtitle = TiConvert.toString(params.get(PROPERTY_REASON_SUBTITLE), "");
+		}
+
 		if (params.containsKey("callback")) {
 			Object callback = params.get("callback");
 			if (callback instanceof KrollFunction) {

--- a/apidoc/Identity.yml
+++ b/apidoc/Identity.yml
@@ -56,7 +56,7 @@ description: |
         } else if (TiIdentity.biometryType === TiIdentity.BIOMETRY_TYPE_TOUCH_ID) { // Touch ID
             authPhrase = 'Touch ID';
         }
-        
+
     ## Face ID Requirements (iOS only)
 
     For Face ID to work properly, you need to add a **`<key>`** item to the
@@ -525,11 +525,23 @@ properties:
   - name: reason
     optional: false
     summary: |
-        Note: This property is iOS only!
-
         Message displayed in the authentication dialog describing why the
-        application is requesting authentication.
+        application is requesting authentication. Android: The title of the dialog.
     type: String
+
+  - name: reasonSubtitle
+    optional: true
+    summary: |
+        Subtitle of the authentication dialog (2nd line).
+    type: String,
+    platforms: [android]
+
+  - name: reasonSubtitle
+    optional: true
+    summary: |
+        Text of the authentication dialog (3rd line).
+    type: String,
+    platforms: [android]
 
   - name: allowableReuseDuration
     summary: |


### PR DESCRIPTION
Use the iOS `reason` to set a custom text. And adding the subtitle and text to have some more options to set:

![Screenshot_20200223-173848](https://user-images.githubusercontent.com/4334997/75115910-7735ff80-5663-11ea-871e-f318d3586434.png)

```javascript
var TiIdentity = require('ti.identity');
var win = Ti.UI.createWindow();

var btn = Ti.UI.createButton({
	title: 'authenticate'
});

win.add(btn);
win.open();

btn.addEventListener('click', function() {

	if (!TiIdentity.isSupported()) {
		alert("Touch ID is not supported on this device!");
		return;
	}

	TiIdentity.authenticate({
		reason: 'Smile...',
		reasonSubtitle: "Subtitle",
		reasonText: "Just the description",
		callback: function(e) {
			if (!e.success) {
				alert('Message: ' + e.error);

			} else {
				alert('YAY! success');
			}
		}
	});
});
```