### PR TITLE
build(ios): build against SDK w/ macos support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,5 @@ android/dist
 /android/java-sources.txt
 
 /ios/metadata.json
-ios/TouchID.xcodeproj/xcuserdata
-ios/TouchID.xcodeproj/project.xcworkspace/xcuserdata
 ios/titanium-identity.xcodeproj/project.xcworkspace/*
+ios/titanium-identity.xcodeproj/xcuserdata/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ library 'pipeline-library'
 def isMaster = env.BRANCH_NAME.equals('master')
 
 buildModule {
-	sdkVersion = '9.0.0.v20200205142057'
+	sdkVersion = '9.2.0.v20200911073932' // use a master build with ARM64 sim, and macOS support
 	npmPublish = isMaster // By default it'll do github release on master anyways too
+	iosLabels = 'osx && xcode-12'
 }

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.1.0
+version: 2.0.0
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: titanium-identity

--- a/ios/manifest
+++ b/ios/manifest
@@ -15,4 +15,4 @@ name: titanium-identity
 moduleid: ti.identity
 guid: ae6ffc93-6e6e-4251-8373-b0cb263a1662
 platform: iphone
-minsdk: 6.2.0
+minsdk: 9.2.0

--- a/ios/titanium.xcconfig
+++ b/ios/titanium.xcconfig
@@ -4,17 +4,12 @@
 // OF YOUR TITANIUM SDK YOU'RE BUILDING FOR
 //
 //
-TITANIUM_SDK_VERSION = 9.0.0.v20200205142057
-
+TITANIUM_SDK_VERSION = 9.2.0.GA
 
 //
 //
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
-TITANIUM_SDK = ~/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
-TITANIUM_BASE_SDK = "$(TITANIUM_SDK)/iphone/include"
-TITANIUM_BASE_SDK2 = "$(TITANIUM_SDK)/iphone/include/TiCore"
-TITANIUM_BASE_SDK3 = "$(TITANIUM_SDK)/iphone/include/ASI"
-TITANIUM_BASE_SDK4 = "$(TITANIUM_SDK)/iphone/include/APSHTTPClient"
-HEADER_SEARCH_PATHS = $(TITANIUM_BASE_SDK) $(TITANIUM_BASE_SDK2) $(TITANIUM_BASE_SDK3) $(TITANIUM_BASE_SDK4)
-FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks"
+TITANIUM_SDK = /Users/$(USER)/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
+HEADER_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/include"
+FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@titanium-sdk/ti.identity",
-	"version": "3.0.2",
+	"version": "4.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@titanium-sdk/ti.identity",
-	"version": "3.0.2",
+	"version": "4.0.0",
 	"description": "A collection of API's to authenticate with your device: Keychain/Keystore, Touch ID and Face ID (iOS only)",
 	"scripts": {
 		"commit": "git-cz",

--- a/test/unit/karma.unit.config.js
+++ b/test/unit/karma.unit.config.js
@@ -12,7 +12,7 @@ module.exports = config => {
 			'karma-*'
 		],
 		titanium: {
-			sdkVersion: config.sdkVersion || '9.0.0.v20200130075800'
+			sdkVersion: config.sdkVersion || '9.2.0.GA'
 		},
 		customLaunchers: {
 			android: {


### PR DESCRIPTION
Needs to be built with SDK from master (Relied on changes from appcelerator/titanium_mobile#12033 to support xcframeworks and macOS)

This is PR  gets the module building with the SDK that enables macOS support and builds as an xcframework (to support arm64 sims when Apple Silicon computers ship!). I've tested locally (and pushed fixes to the SDK) to get this working. I was able to test an iPhone sim and macOS catalyst locally.

The most relevant change here is to the `iOS/titanium.xcconfig` using a recursive path for `FRAMEWORK_SEARCH_PATHS`. Because the SDK packages TitaniumKit as an XCFramework, the underlying framework folders are underneath each os/arch combo parent.

**NOTE** This actually just worked as expected on my local MacBook Pro - the example app prompted me for TouchID and authenticated!

<img width="795" alt="Screen Shot 2020-09-01 at 3 51 59 PM" src="https://user-images.githubusercontent.com/3252/91899618-6a761200-ec6b-11ea-8a15-9dd3c580ae11.png">
<img width="797" alt="Screen Shot 2020-09-01 at 3 52 10 PM" src="https://user-images.githubusercontent.com/3252/91899625-6cd86c00-ec6b-11ea-89e3-f9c911446420.png">
