### PR TITLE
feat(android): isEnabled() check

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.1.1
+version: 3.3.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-identity
@@ -15,4 +15,4 @@ name: titanium-identity
 moduleid: ti.identity
 guid: c3d987a8-8bd4-42cd-a3e4-2a75952d1ea0
 platform: android
-minsdk: 9.0.0
+minsdk: 13.1.0

--- a/android/src/ti/identity/FingerPrintHelper.java
+++ b/android/src/ti/identity/FingerPrintHelper.java
@@ -126,6 +126,20 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 		}
 	}
 
+	public boolean isEnabled()
+	{
+		if (canUseDeviceBiometrics()) {
+			try {
+				initCipher();
+				mCryptoObject = new BiometricPrompt.CryptoObject(mCipher);
+			} catch (Exception e) {}
+            if (mCryptoObject != null) {
+				return true;
+			} else return canUseDeviceCredentials();
+		}
+		return false;
+	}
+
 	@SuppressLint("MissingPermission,NewApi")
 	public void startListening(KrollFunction callback, KrollObject obj)
 	{
@@ -155,6 +169,9 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 				prompt.authenticate(promptInfo.build(), mCryptoObject);
 			} else if (canUseDeviceCredentials()) {
 				startDeviceCredentials();
+			} else {
+				// fire error
+				onError("Failed to init Cipher");
 			}
 		} else if (canUseDeviceCredentials()) {
 			this.callback = callback;

--- a/android/src/ti/identity/FingerPrintHelper.java
+++ b/android/src/ti/identity/FingerPrintHelper.java
@@ -132,10 +132,12 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 			try {
 				initCipher();
 				mCryptoObject = new BiometricPrompt.CryptoObject(mCipher);
-			} catch (Exception e) {}
-            if (mCryptoObject != null) {
+			} catch (Exception e) {
+			}
+			if (mCryptoObject != null) {
 				return true;
-			} else return canUseDeviceCredentials();
+			} else
+				return canUseDeviceCredentials();
 		}
 		return false;
 	}

--- a/android/src/ti/identity/KeychainItemProxy.java
+++ b/android/src/ti/identity/KeychainItemProxy.java
@@ -120,46 +120,45 @@ public class KeychainItemProxy extends KrollProxy
 			context = TiApplication.getAppRootOrCurrentActivity();
 
 			// fingerprint authentication
-            keyguardManager = context.getSystemService(KeyguardManager.class);
-            biometricManager = BiometricManager.from(context);
-            authenticationCallback = new AuthenticationCallback() {
-                @Override
-                public void onAuthenticationError(int errorCode, CharSequence errString)
-                {
-                    switch (errorCode) {
-                        case BiometricPrompt.ERROR_USER_CANCELED:
-                        case BiometricPrompt.ERROR_CANCELED:
-                        case BiometricPrompt.ERROR_NEGATIVE_BUTTON:
-                            doEvents(TitaniumIdentityModule.ERROR_AUTHENTICATION_FAILED, errString.toString());
-                            break;
-                        default:
-                            doEvents(errorCode, errString.toString());
-                    }
-                }
+			keyguardManager = context.getSystemService(KeyguardManager.class);
+			biometricManager = BiometricManager.from(context);
+			authenticationCallback = new AuthenticationCallback() {
+				@Override
+				public void onAuthenticationError(int errorCode, CharSequence errString)
+				{
+					switch (errorCode) {
+						case BiometricPrompt.ERROR_USER_CANCELED:
+						case BiometricPrompt.ERROR_CANCELED:
+						case BiometricPrompt.ERROR_NEGATIVE_BUTTON:
+							doEvents(TitaniumIdentityModule.ERROR_AUTHENTICATION_FAILED, errString.toString());
+							break;
+						default:
+							doEvents(errorCode, errString.toString());
+					}
+				}
 
-                @Override
-                public void onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult result)
-                {
-                    doEvents(0, null);
-                }
+				@Override
+				public void onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult result)
+				{
+					doEvents(0, null);
+				}
 
-                @Override
-                public void onAuthenticationFailed()
-                {
-                    doEvents(TitaniumIdentityModule.ERROR_AUTHENTICATION_FAILED,
-                             "failed to authenticate fingerprint!");
-                }
-            };
+				@Override
+				public void onAuthenticationFailed()
+				{
+					doEvents(TitaniumIdentityModule.ERROR_AUTHENTICATION_FAILED, "failed to authenticate fingerprint!");
+				}
+			};
 
-            final BiometricPrompt.PromptInfo.Builder promptInfo = new BiometricPrompt.PromptInfo.Builder();
-            promptInfo.setTitle(TitaniumIdentityModule.reason);
-            promptInfo.setSubtitle(TitaniumIdentityModule.reasonSubtitle);
-            promptInfo.setDescription(TitaniumIdentityModule.reasonText);
-            promptInfo.setNegativeButtonText(TitaniumIdentityModule.negativeButtonText);
-            promptInfo.setConfirmationRequired(TitaniumIdentityModule.confirmationRequired);
-            biometricPromptInfo = promptInfo.build();
+			final BiometricPrompt.PromptInfo.Builder promptInfo = new BiometricPrompt.PromptInfo.Builder();
+			promptInfo.setTitle(TitaniumIdentityModule.reason);
+			promptInfo.setSubtitle(TitaniumIdentityModule.reasonSubtitle);
+			promptInfo.setDescription(TitaniumIdentityModule.reasonText);
+			promptInfo.setNegativeButtonText(TitaniumIdentityModule.negativeButtonText);
+			promptInfo.setConfirmationRequired(TitaniumIdentityModule.confirmationRequired);
+			biometricPromptInfo = promptInfo.build();
 
-            // load Android key store
+			// load Android key store
 			keyStore = KeyStore.getInstance("AndroidKeyStore");
 			keyStore.load(null);
 

--- a/android/src/ti/identity/KeychainItemProxy.java
+++ b/android/src/ti/identity/KeychainItemProxy.java
@@ -120,48 +120,46 @@ public class KeychainItemProxy extends KrollProxy
 			context = TiApplication.getAppRootOrCurrentActivity();
 
 			// fingerprint authentication
-			if (Build.VERSION.SDK_INT >= 23) {
-				keyguardManager = context.getSystemService(KeyguardManager.class);
-				biometricManager = BiometricManager.from(context);
-				authenticationCallback = new AuthenticationCallback() {
-					@Override
-					public void onAuthenticationError(int errorCode, CharSequence errString)
-					{
-						switch (errorCode) {
-							case BiometricPrompt.ERROR_USER_CANCELED:
-							case BiometricPrompt.ERROR_CANCELED:
-							case BiometricPrompt.ERROR_NEGATIVE_BUTTON:
-								doEvents(TitaniumIdentityModule.ERROR_AUTHENTICATION_FAILED, errString.toString());
-								break;
-							default:
-								doEvents(errorCode, errString.toString());
-						}
-					}
+            keyguardManager = context.getSystemService(KeyguardManager.class);
+            biometricManager = BiometricManager.from(context);
+            authenticationCallback = new AuthenticationCallback() {
+                @Override
+                public void onAuthenticationError(int errorCode, CharSequence errString)
+                {
+                    switch (errorCode) {
+                        case BiometricPrompt.ERROR_USER_CANCELED:
+                        case BiometricPrompt.ERROR_CANCELED:
+                        case BiometricPrompt.ERROR_NEGATIVE_BUTTON:
+                            doEvents(TitaniumIdentityModule.ERROR_AUTHENTICATION_FAILED, errString.toString());
+                            break;
+                        default:
+                            doEvents(errorCode, errString.toString());
+                    }
+                }
 
-					@Override
-					public void onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult result)
-					{
-						doEvents(0, null);
-					}
+                @Override
+                public void onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult result)
+                {
+                    doEvents(0, null);
+                }
 
-					@Override
-					public void onAuthenticationFailed()
-					{
-						doEvents(TitaniumIdentityModule.ERROR_AUTHENTICATION_FAILED,
-								 "failed to authenticate fingerprint!");
-					}
-				};
+                @Override
+                public void onAuthenticationFailed()
+                {
+                    doEvents(TitaniumIdentityModule.ERROR_AUTHENTICATION_FAILED,
+                             "failed to authenticate fingerprint!");
+                }
+            };
 
-				final BiometricPrompt.PromptInfo.Builder promptInfo = new BiometricPrompt.PromptInfo.Builder();
-				promptInfo.setTitle(TitaniumIdentityModule.reason);
-				promptInfo.setSubtitle(TitaniumIdentityModule.reasonSubtitle);
-				promptInfo.setDescription(TitaniumIdentityModule.reasonText);
-				promptInfo.setNegativeButtonText(TitaniumIdentityModule.negativeButtonText);
-				promptInfo.setConfirmationRequired(TitaniumIdentityModule.confirmationRequired);
-				biometricPromptInfo = promptInfo.build();
-			}
+            final BiometricPrompt.PromptInfo.Builder promptInfo = new BiometricPrompt.PromptInfo.Builder();
+            promptInfo.setTitle(TitaniumIdentityModule.reason);
+            promptInfo.setSubtitle(TitaniumIdentityModule.reasonSubtitle);
+            promptInfo.setDescription(TitaniumIdentityModule.reasonText);
+            promptInfo.setNegativeButtonText(TitaniumIdentityModule.negativeButtonText);
+            promptInfo.setConfirmationRequired(TitaniumIdentityModule.confirmationRequired);
+            biometricPromptInfo = promptInfo.build();
 
-			// load Android key store
+            // load Android key store
 			keyStore = KeyStore.getInstance("AndroidKeyStore");
 			keyStore.load(null);
 
@@ -574,8 +572,7 @@ public class KeychainItemProxy extends KrollProxy
 							!= 0) {
 							spec.setUserAuthenticationRequired(true);
 						}
-						if ((accessControlMode & ACCESS_CONTROL_TOUCH_ID_CURRENT_SET) != 0
-							&& Build.VERSION.SDK_INT >= 24) {
+						if ((accessControlMode & ACCESS_CONTROL_TOUCH_ID_CURRENT_SET) != 0) {
 							spec.setInvalidatedByBiometricEnrollment(true);
 						}
 

--- a/android/src/ti/identity/TitaniumIdentityModule.java
+++ b/android/src/ti/identity/TitaniumIdentityModule.java
@@ -124,16 +124,14 @@ public class TitaniumIdentityModule extends KrollModule
 
 	private void init()
 	{
-		if (Build.VERSION.SDK_INT >= 23) {
-			try {
-				mfingerprintHelper = new FingerPrintHelper(this);
-			} catch (Exception e) {
-				mfingerprintHelper = null;
-				fingerprintHelperException = e.getCause();
-				Log.e(TAG, fingerprintHelperException.getMessage());
-			}
-		}
-	}
+        try {
+            mfingerprintHelper = new FingerPrintHelper(this);
+        } catch (Exception e) {
+            mfingerprintHelper = null;
+            fingerprintHelperException = e.getCause();
+            Log.e(TAG, fingerprintHelperException.getMessage());
+        }
+    }
 
 	@Override
 	public void propertyChanged(String key, Object oldValue, Object newValue, KrollProxy proxy)
@@ -182,20 +180,18 @@ public class TitaniumIdentityModule extends KrollModule
 		if (mfingerprintHelper == null) {
 			init();
 		}
-		if (Build.VERSION.SDK_INT >= 23 && mfingerprintHelper != null) {
+		if (mfingerprintHelper != null) {
 			return mfingerprintHelper.deviceCanAuthenticate(authenticationPolicy);
 		}
 
 		KrollDict response = new KrollDict();
 		response.put("canAuthenticate", false);
 		response.put("code", TitaniumIdentityModule.ERROR_TOUCH_ID_NOT_AVAILABLE);
-		if (Build.VERSION.SDK_INT < 23) {
-			response.put("error", "Device is running with API < 23");
-		} else if (fingerprintHelperException != null) {
-			response.put("error", fingerprintHelperException.getMessage());
-		} else {
-			response.put("error", "Device does not support fingerprint authentication");
-		}
+        if (fingerprintHelperException != null) {
+            response.put("error", fingerprintHelperException.getMessage());
+        } else {
+            response.put("error", "Device does not support fingerprint authentication");
+        }
 
 		return response;
 	}
@@ -206,8 +202,20 @@ public class TitaniumIdentityModule extends KrollModule
 		if (mfingerprintHelper == null) {
 			init();
 		}
-		if (Build.VERSION.SDK_INT >= 23 && mfingerprintHelper != null) {
+		if (mfingerprintHelper != null) {
 			return mfingerprintHelper.isDeviceSupported();
+		}
+		return false;
+	}
+
+	@Kroll.method
+	public boolean isEnabled()
+	{
+		if (mfingerprintHelper == null) {
+			init();
+		}
+		if (mfingerprintHelper != null) {
+			return mfingerprintHelper.isEnabled();
 		}
 		return false;
 	}

--- a/android/src/ti/identity/TitaniumIdentityModule.java
+++ b/android/src/ti/identity/TitaniumIdentityModule.java
@@ -124,14 +124,14 @@ public class TitaniumIdentityModule extends KrollModule
 
 	private void init()
 	{
-        try {
-            mfingerprintHelper = new FingerPrintHelper(this);
-        } catch (Exception e) {
-            mfingerprintHelper = null;
-            fingerprintHelperException = e.getCause();
-            Log.e(TAG, fingerprintHelperException.getMessage());
-        }
-    }
+		try {
+			mfingerprintHelper = new FingerPrintHelper(this);
+		} catch (Exception e) {
+			mfingerprintHelper = null;
+			fingerprintHelperException = e.getCause();
+			Log.e(TAG, fingerprintHelperException.getMessage());
+		}
+	}
 
 	@Override
 	public void propertyChanged(String key, Object oldValue, Object newValue, KrollProxy proxy)
@@ -187,11 +187,11 @@ public class TitaniumIdentityModule extends KrollModule
 		KrollDict response = new KrollDict();
 		response.put("canAuthenticate", false);
 		response.put("code", TitaniumIdentityModule.ERROR_TOUCH_ID_NOT_AVAILABLE);
-        if (fingerprintHelperException != null) {
-            response.put("error", fingerprintHelperException.getMessage());
-        } else {
-            response.put("error", "Device does not support fingerprint authentication");
-        }
+		if (fingerprintHelperException != null) {
+			response.put("error", fingerprintHelperException.getMessage());
+		} else {
+			response.put("error", "Device does not support fingerprint authentication");
+		}
 
 		return response;
 	}

--- a/apidoc/Identity.yml
+++ b/apidoc/Identity.yml
@@ -159,6 +159,15 @@ methods:
     returns:
         type: Boolean
 
+  - name: isEnabled
+    summary: Determines if the current state of the biometric authentication.
+    description: |
+        Will return `false` if the device has biometrics but they are disabled
+    platforms: [android]
+    since: "13.1.1"
+    returns:
+        type: Boolean
+
 properties:
   - name: authenticationPolicy
     summary: Sets the global authentication policy used in this Touch ID / Face ID context.

--- a/example/app.js
+++ b/example/app.js
@@ -48,6 +48,11 @@ var btn = Ti.UI.createButton({
 win.add(btn);
 win.open();
 
+win.addEventListener("open", function(){
+	console.log("is supported: " + TiIdentity.isSupported());
+	console.log("is enabled: " + TiIdentity.isEnabled());
+})
+
 btn.addEventListener('click', function () {
 	if (!supported) {
 		alert('Authentication is not supported on this device!'); // eslint-disable-line no-alert

--- a/example/app.js
+++ b/example/app.js
@@ -48,10 +48,10 @@ var btn = Ti.UI.createButton({
 win.add(btn);
 win.open();
 
-win.addEventListener("open", function(){
-	console.log("is supported: " + TiIdentity.isSupported());
-	console.log("is enabled: " + TiIdentity.isEnabled());
-})
+win.addEventListener('open', function () {
+	console.log('is supported: ' + TiIdentity.isSupported());
+	console.log('is enabled: ' + TiIdentity.isEnabled());
+});
 
 btn.addEventListener('click', function () {
 	if (!supported) {


### PR DESCRIPTION
* new method `isEnabled()` that will show true/false if you have biometrics but they are disabled
* `authenticate()` will call the error callback if biometrics are disabled
* removed some minSdk checks as Ti 13.1.0 is minSdk 24 now by default
* fixed manifest version number


[ti.identity-android-3.3.0.zip](https://github.com/user-attachments/files/24968021/ti.identity-android-3.3.0.zip)


**Note:** 
`authenticate()` will currently also fail if the device has the feature disabled. `isSupported()` is still showing true because the devices HAS the features. The `isEnabled()` will do the same checks as `authenticate()` but won't show the dialog in case it is true. So you can use the check beforehand.